### PR TITLE
Changing OSCClient and OSCServer from public to open

### DIFF
--- a/Framework/SwiftOSC/Communication/OSCClient.swift
+++ b/Framework/SwiftOSC/Communication/OSCClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-@objc public class OSCClient: NSObject {
-    public var address: String {
+@objc open class OSCClient: NSObject {
+    open var address: String {
         didSet {
             _ = client.close()
             client = UDPClient(addr: address, port: port)
         }
     }
-    public var port: Int {
+    open var port: Int {
         didSet {
             _ = client.close()
             client = UDPClient(addr: address, port: port)
@@ -21,7 +21,7 @@ import Foundation
         client = UDPClient(addr: address, port: port)
         client.enableBroadcast()
     }
-    public func send(_ element: OSCElement){
+    open func send(_ element: OSCElement){
         var data = element.data
         if data.count > 9216 {
             print("OSCPacket is too large. Must be smaller than 9200 bytes")

--- a/Framework/SwiftOSC/Communication/OSCServer.swift
+++ b/Framework/SwiftOSC/Communication/OSCServer.swift
@@ -11,21 +11,21 @@ extension OSCServerDelegate {
     public func didReceive(_ message: OSCMessage){}
 }
 
-public class OSCServer {
-    public var address: String {
+open class OSCServer {
+    open var address: String {
         didSet {
             _ = server.close()
             server = UDPServer(addr: self.address, port:self.port)
         }
     }
-    public var port: Int {
+    open var port: Int {
         didSet {
             _ = server.close()
             server = UDPServer(addr: self.address, port:self.port)
         }
     }
-    public var delegate: OSCServerDelegate?
-    public var running = false
+    open var delegate: OSCServerDelegate?
+    open var running = false
     var server: UDPServer
     
     public init(address: String, port: Int){
@@ -35,10 +35,10 @@ public class OSCServer {
         run()
     }
     
-    public func start(){
+    open func start(){
         running = true
     }
-    public func stop(){
+    open func stop(){
         running = false
     }
     func run() {


### PR DESCRIPTION
All access levels for these two classes that were `public` are now `open`, with one exception. The inits set a property that's not set as `public`. To not break that access control, the inits cannot be overridden and remain as `public`.

This will allow folks to subclass `OSCClient` and `OSCServer` mostly for the purposes of mocking in unit tests.

**NOTE:**
This pull request does not modify the podspec, any build numbers or versions, or the README. These should be modified as required by the repo owner.